### PR TITLE
Fix CSS dev mode issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ public/build/
 /build
 /dist
 app/styles/
-styles/components/
+styles/index.css
 
 # mocks
 src/assets/images/mocks

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 public/build/
 /build
 /dist
-app/styles/
+app/css/
 styles/index.css
 
 # mocks

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,7 +8,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from '@remix-run/react';
-import styles from './styles/app.css';
+import styles from './css/app.css';
 
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',

--- a/app/routes/__main.tsx
+++ b/app/routes/__main.tsx
@@ -9,7 +9,7 @@ import SettingsProvider from '~/context/settingsContext/settingsContextProvider'
 import SocketContext from '~/context/socketContext/socketContextProvider';
 import MainHeader from '~/components/MainHeader';
 import Player from '~/components/Player';
-import styles from '~/styles/routes/__main.css';
+import styles from '~/css/routes/__main.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/agreement/index.tsx
+++ b/app/routes/__main/agreement/index.tsx
@@ -9,7 +9,7 @@ import { PrimaryButton } from '~/components/common/Button';
 import { Checkbox } from '~/components/common/Checkbox';
 import { PartialView } from '~/components/PartialView';
 import { TextLink } from '~/components/common/Link';
-import styles from '~/styles/routes/__main/agreements.css';
+import styles from '~/css/routes/__main/agreements.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/album/$id.tsx
+++ b/app/routes/__main/album/$id.tsx
@@ -15,7 +15,7 @@ import { getSession } from '~/hooks/useSession';
 import Collection from '~/components/Collection';
 import AlbumSummary from '~/components/Summary/AlbumSummary';
 import { collectionThemes } from '~/components/Collection/types';
-import styles from '~/styles/routes/__main/album.css';
+import styles from '~/css/routes/__main/album.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/artist/$id.tsx
+++ b/app/routes/__main/artist/$id.tsx
@@ -14,7 +14,7 @@ import { ProfileContext } from '~/context/profileContext/profileContextProvider'
 import { getSession } from '~/hooks/useSession';
 import Collection from '~/components/Collection';
 import ArtistSummary from '~/components/Summary/ArtistSummary';
-import styles from '~/styles/routes/__main/artist.css';
+import styles from '~/css/routes/__main/artist.css';
 import { artistLoaderProps, ArtistLoaderData } from '../../types';
 
 export function links() {

--- a/app/routes/__main/index/index.tsx
+++ b/app/routes/__main/index/index.tsx
@@ -16,7 +16,7 @@ import { getSession } from '~/hooks/useSession';
 import Collection from '~/components/Collection';
 import { entityThemes } from '~/components/Entity/types';
 import { collectionThemes } from '~/components/Collection/types';
-import styles from '~/styles/routes/__main/index.css';
+import styles from '~/css/routes/__main/index.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/login/index.tsx
+++ b/app/routes/__main/login/index.tsx
@@ -13,7 +13,7 @@ import { PartialView } from '~/components/PartialView';
 import SecretKeyInput from '~/components/SecretKeyInput';
 import { DERIVATION_PATH } from '~/constants/app';
 import { LoginLoaderProps } from '../../types';
-import styles from '~/styles/routes/__main/login.css';
+import styles from '~/css/routes/__main/login.css';
 
 export const validateCredentials = async (secret: string) => {
   const privateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(secret, DERIVATION_PATH);

--- a/app/routes/__main/playlist/$id.tsx
+++ b/app/routes/__main/playlist/$id.tsx
@@ -14,7 +14,7 @@ import { ProfileContext } from '~/context/profileContext/profileContextProvider'
 import { getSession } from '~/hooks/useSession';
 import Collection from '~/components/Collection';
 import PlaylistSummary from '~/components/Summary/PlaylistSummary';
-import styles from '~/styles/routes/__main/playlist.css';
+import styles from '~/css/routes/__main/playlist.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/profile/__main.tsx
+++ b/app/routes/__main/profile/__main.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 /* Internal dependencies */
-import styles from '~/styles/routes/__main/profile.css';
+import styles from '~/css/routes/__main/profile.css';
 import { ProfileContext } from '~/context/profileContext/profileContextProvider';
 import { Tabs } from '~/components/common/Tabs';
 import { ProfileLoaderProps, ProfileLoaderData } from '../../types';

--- a/app/routes/__main/register/index.tsx
+++ b/app/routes/__main/register/index.tsx
@@ -7,7 +7,7 @@ import { PrimaryButton } from '~/components/common/Button';
 import { PartialView } from '~/components/PartialView';
 import { SecretKey } from '~/components/SecretKey';
 import Icon from '~/components/common/Icon';
-import styles from '~/styles/routes/__main/register.css';
+import styles from '~/css/routes/__main/register.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/search/index.tsx
+++ b/app/routes/__main/search/index.tsx
@@ -11,7 +11,7 @@ import {
 import Collection from '~/components/Collection';
 import { Input } from '~/components/common/Input';
 import { Entity, entityThemes } from '~/components/Entity/types';
-import styles from '~/styles/routes/__main/search.css';
+import styles from '~/css/routes/__main/search.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/settings/index.tsx
+++ b/app/routes/__main/settings/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styles from '~/styles/routes/__main/settings.css';
+import styles from '~/css/routes/__main/settings.css';
 
 export function links() {
   return [{ rel: 'stylesheet', href: styles }];

--- a/app/routes/__main/subscription/__main.tsx
+++ b/app/routes/__main/subscription/__main.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Outlet} from '@remix-run/react';
 
 /* Internal dependencies */
-import styles from '~/styles/routes/__main/subscription.css';
+import styles from '~/css/routes/__main/subscription.css';
 import {Tabs} from '~/components/common/Tabs';
 
 export function links() {

--- a/collectStyles.sh
+++ b/collectStyles.sh
@@ -1,11 +1,7 @@
 rm -rf ./styles/components
-mkdir ./styles/components
-touch ./styles/components/index.css
-INDEX_FILE="./styles/components/index.css"
-# find ./app/components -name '*.css' -exec cp -prv '{}' './styles/components/' ';'
+rm ./styles/index.css
+touch ./styles/index.css
+INDEX_FILE="./styles/index.css"
 find ./app/components -name '*.css' | while IFS= read -r FILE; do
-    BASE_NAME=$(basename ${FILE})
-    # echo "Copying $FILE......$BASE_NAME"
-    cp "$FILE" ./styles/components/
-    echo "@import './$BASE_NAME';" >> $INDEX_FILE
+    echo "@import '.$FILE';" >> $INDEX_FILE
 done

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "author": "Block Made GmbH",
   "license": "ISC",
   "scripts": {
-    "build": "remix build",
+    "build": "npm run build:css && remix build",
     "remix:dev": "remix build && run-p \"dev:*\"",
     "dev": "concurrently \"npm run dev:css\" \"npm run remix:dev\"",
     "dev:node": "cross-env NODE_ENV=development nodemon ./server.js --watch ./server.js",
     "postinstall": "patch-package && remix-esbuild-override",
     "dev:remix": "remix watch",
     "start": "cross-env NODE_ENV=production node ./server.js",
-    "dev:css": "sh collectStyles.sh && postcss styles --base styles --dir app/styles -w",
-    "build:css": "sh collectStyles.sh && postcss styles --base styles --dir app/styles --env production",
+    "dev:css": "sh collectStyles.sh && postcss styles --base styles --dir app/css -w",
+    "build:css": "sh collectStyles.sh && postcss styles --base styles --dir app/css --env production",
     "lint": "npx eslint app --ext .js,.jsx,.ts,.tsx --fix",
     "test": "jest --config ./jest.config.js"
   },

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,6 +1,6 @@
 @import './variables.css';
 @import './typography.css';
-@import './components/index.css';
+@import './index.css';
 
 body {
   padding: 0;


### PR DESCRIPTION
### Which issues does this PR address?
Closes #52


### how did you resolve?
The bash script was copying the styles from the `app/components` directly, to collect them in `styles/components`. Then the `styles/app.css` imported them from `styles/components/index.css`.
I changed the bash script to create `styles/index.css` and import it in `styles/app.css`. The `index.css` file imports CSS files  directly from `app/components`, hence when you change them the dev script gets triggered and updated the styles.

This means, you only need to run `npm run dev` once more if you add a new CSS file. But you don't need to restart it when you apply changes in existing CSS files.

I've also renamed the generated styles directory to `css`, so remove the confusion. Now it's clear that styles to be updated reside in the `styles` directory. 