### PR TITLE
Submit stream transaction when a audio is being streamed 

### DIFF
--- a/app/components/Player/PlayerContent.tsx
+++ b/app/components/Player/PlayerContent.tsx
@@ -42,6 +42,7 @@ const PlayerContent = () => {
       <audio
         src={current?.audioID ? `${API_URLS.STREAMER}/api/v1/audios/stream/${current?.audioID}` : ''}
         ref={audioRef}
+        data-audio-id={current?.audioID}
         onTimeUpdate={onTimeUpdate}
       />
       <ProgressBar

--- a/app/constants/blockchain.ts
+++ b/app/constants/blockchain.ts
@@ -7,6 +7,7 @@ export const MODULES = {
 };
 
 export const COMMANDS = {
+  STREAM: 'stream',
   CREATE: 'create',
   PURCHASE: 'purchase',
   TRANSFORM: 'transform',
@@ -89,6 +90,19 @@ export const AUDIO_CREATE_SCHEMA = {
     meta: {
       dataType: 'bytes',
       fieldNumber: 8,
+    },
+  },
+};
+
+export const AUDIO_STREAM_SCHEMA = {
+  $id: 'audio/stream',
+  title: 'StreamAsset transaction asset for audio module',
+  type: 'object',
+  required: ['audioID'],
+  properties: {
+    audioID: {
+      dataType: 'bytes',
+      fieldNumber: 1,
     },
   },
 };

--- a/app/context/socketContext/types.ts
+++ b/app/context/socketContext/types.ts
@@ -43,8 +43,15 @@ interface PostTxData {
   transactionID: string;
 }
 
-interface DryRunTxData {
-  events: string[];
+interface BlockEvent {
+  module: string;
+  name: string;
+  topics: string[];
+  data: string;
+}
+
+export interface DryRunTxData {
+  events: BlockEvent[];
   success: boolean;
   result: number;
 }
@@ -107,7 +114,7 @@ export interface RequestParams {
   [key: string]: string;
 }
 
-interface ErrorResponse {
+export interface ErrorResponse {
   message: string;
   error: true;
 }

--- a/app/helpers/helpers.ts
+++ b/app/helpers/helpers.ts
@@ -1,9 +1,3 @@
-const {
-  SUCCESS_CODE,
-  TX_STATUS,
-  UNDETERMINED_EVENT_ERROR,
-} = require('~/constants/app');
-
 export const greet = (timestamp = 0) => {
   const date = timestamp ? new Date(timestamp) : new Date();
   const hour = date.getHours();
@@ -58,11 +52,3 @@ export const waitFor = (seconds: number): Promise<void> =>
       resolve();
     }, seconds * 1000);
   });
-
-export const getTransactionExecutionStatus = (module: string, id: string, events: any[]) => {
-  const expectedEventName = `${module}:commandExecutionResult`;
-  const commandExecResultEvents = events.filter(e => `${e.module}:${e.name}` === expectedEventName);
-  const txExecResultEvent = commandExecResultEvents.find(e => e.topics.includes(id));
-  if (!txExecResultEvent) throw Error(`${UNDETERMINED_EVENT_ERROR}: ${id}.`);
-  return txExecResultEvent.data === SUCCESS_CODE ? TX_STATUS.SUCCESS : TX_STATUS.FAIL;
-};

--- a/app/helpers/transaction.test.ts
+++ b/app/helpers/transaction.test.ts
@@ -1,0 +1,47 @@
+import { TX_STATUS } from '~/constants/app';
+import { DryRunTxResponse, ErrorResponse } from '~/context/socketContext/types';
+import {
+  getTransactionExecutionStatus,
+} from './transaction';
+
+describe('Transaction', () => {
+  const dryRunCallError = {
+    error: true,
+    message: 'error',
+  } as ErrorResponse;
+  const DryRunExecutionError = {
+    error: false,
+    data: {
+      events: [
+        { module: 'audio', name: 'commandExecutionResult', topics: ['123'], data: '0800' }
+      ],
+    },
+  } as DryRunTxResponse;
+  const DryRunExecutionSuccess = {
+    error: false,
+    data: {
+      events: [
+        { module: 'audio', name: 'commandExecutionResult', topics: ['123'], data: '0801' }
+      ],
+    },
+  } as DryRunTxResponse;
+  const module = 'audio';
+  const id = '123';
+
+  describe('getTransactionExecutionStatus', () => {
+    it('should return FAIL if response has error', () => {
+      const result = getTransactionExecutionStatus(module, id, dryRunCallError);
+      expect(result).toBe(TX_STATUS.FAIL);
+    });
+
+    it('should return FAIL if response has an event with data 0800', () => {
+      const result = getTransactionExecutionStatus(module, id, DryRunExecutionError);
+      expect(result).toBe(TX_STATUS.FAIL);
+    });
+
+    it('should return SUCCESS if response has an event with data 0801', () => {
+      const result = getTransactionExecutionStatus(module, id, DryRunExecutionSuccess);
+      expect(result).toBe(TX_STATUS.SUCCESS);
+    });
+  });
+});

--- a/app/helpers/transaction.ts
+++ b/app/helpers/transaction.ts
@@ -1,0 +1,22 @@
+import { DryRunTxResponse } from '~/context/socketContext/types';
+
+const {
+  SUCCESS_CODE,
+  TX_STATUS,
+} = require('~/constants/app');
+
+export const getTransactionExecutionStatus = (module: string, id: string, response: DryRunTxResponse) => {
+  if (response.error || !response.data.events.length) {
+    return TX_STATUS.FAIL;
+  }
+
+  const expectedEventName = `${module}:commandExecutionResult`;
+  const commandExecResultEvents = response.data.events.filter((e) =>
+    `${e.module}:${e.name}` === expectedEventName);
+  const txExecResultEvent = commandExecResultEvents.find((e) =>
+    e.topics.includes(id));
+  if (!txExecResultEvent) {
+    return TX_STATUS.FAIL;
+  }
+  return txExecResultEvent.data === SUCCESS_CODE ? TX_STATUS.SUCCESS : TX_STATUS.FAIL;
+};

--- a/app/hooks/useAudio/useAudio.ts
+++ b/app/hooks/useAudio/useAudio.ts
@@ -4,13 +4,16 @@ import {
   MutableRefObject,
   useContext,
 } from 'react';
+
 import { PlayerContext } from '~/context/playerContext/playerContextProvider';
+import { useStream } from '../useStream';
 
 export const useAudio = (audioRef: MutableRefObject<HTMLAudioElement>) => {
   const {
     isPlaying,
     setIsPlaying,
   } = useContext(PlayerContext);
+  const { registerStream } = useStream();
   const [progress, setProgress] = useState(0);
   const [duration, setDuration] = useState(0);
   const onAudioEnd = () => {
@@ -35,6 +38,10 @@ export const useAudio = (audioRef: MutableRefObject<HTMLAudioElement>) => {
     setDuration(Math.floor(e.target?.duration ?? 0));
     audioRef.current.play();
     setIsPlaying(true);
+    const audioID = audioRef.current.getAttribute('data-audio-id');
+    if (audioID) {
+      registerStream(audioID);
+    }
   };
 
   // Implements seek functionality

--- a/app/hooks/useCreateEntity/useCreateAlbum.ts
+++ b/app/hooks/useCreateEntity/useCreateAlbum.ts
@@ -104,6 +104,12 @@ export const useCreateAlbum = () => {
       Buffer.from(data.privateKey, 'hex'),
       COLLECTION_CREATE_SCHEMA
     );
+    if (!signedTx.id || !Buffer.isBuffer(signedTx.id)) {
+      return {
+        txBytes: '',
+        txId: '',
+      }
+    }
     const txId = signedTx.id.toString('hex');
     const txBytes = transactions.getBytes(signedTx, COLLECTION_CREATE_SCHEMA);
     // dry-run transaction to get the errors

--- a/app/hooks/useCreateEntity/useCreateAlbum.ts
+++ b/app/hooks/useCreateEntity/useCreateAlbum.ts
@@ -112,7 +112,7 @@ export const useCreateAlbum = () => {
       { transaction: txBytes.toString('hex') },
     );
     // broadcast transaction
-    const txStatus = getTransactionExecutionStatus(MODULES.SUBSCRIPTION, txId, dryRunResponse.data.events);
+    const txStatus = getTransactionExecutionStatus(MODULES.COLLECTION, txId, dryRunResponse);
     if (txStatus === TX_STATUS.SUCCESS) {
       const response = await request(
         Method.txpool_postTransaction,

--- a/app/hooks/useCreateEntity/useCreateAlbum.ts
+++ b/app/hooks/useCreateEntity/useCreateAlbum.ts
@@ -2,7 +2,6 @@
 import { useState, ChangeEvent, useEffect } from 'react';
 import { transactions, cryptography } from '@liskhq/lisk-client';
 import md5 from 'md5';
-import BigNumber from 'bignumber.js';
 
 /* Internal dependencies */
 import { useAccount } from '~/hooks/useAccount/useAccount';
@@ -24,7 +23,7 @@ import { useWS } from '../useWS/useWS';
 import { ValidationStatus } from './types';
 import { validate } from './validator';
 import { postAlbum } from '~/models/entity.client';
-import { getTransactionExecutionStatus } from '~/helpers/helpers';
+import { getTransactionExecutionStatus } from '~/helpers/transaction';
 
 export const useCreateAlbum = () => {
   const { updateAccount } = useAccount();
@@ -85,7 +84,7 @@ export const useCreateAlbum = () => {
     const tx = {
       module: MODULES.COLLECTION,
       command: COMMANDS.CREATE,
-      nonce: BigNumber(data.nonce),
+      nonce: BigInt(data.nonce),
       senderPublicKey: Buffer.from(data.publicKey, 'hex'),
       params: {
         name,
@@ -150,7 +149,6 @@ export const useCreateAlbum = () => {
       }
     } else {
       setFeedback({ message: FEEDBACK_MESSAGES.INVALID_PARAMS, error: true });
-      // Set errors and display to user
     }
   };
 

--- a/app/hooks/useCreateEntity/useCreateTrack.ts
+++ b/app/hooks/useCreateEntity/useCreateTrack.ts
@@ -2,7 +2,6 @@
 import { useState, ChangeEvent, useEffect } from 'react';
 import { transactions, cryptography } from '@liskhq/lisk-client';
 import md5 from 'md5';
-import BigNumber from 'bignumber.js';
 
 /* Internal dependencies */
 import { useAccount } from '~/hooks/useAccount/useAccount';
@@ -25,7 +24,7 @@ import { useWS } from '../useWS/useWS';
 import { ValidationStatus } from './types';
 import { validate } from './validator';
 import { postTrack } from '~/models/entity.client';
-import { getTransactionExecutionStatus } from '~/helpers/helpers';
+import { getTransactionExecutionStatus } from '~/helpers/transaction';
 
 export const useCreateTrack = () => {
   const { updateAccount } = useAccount();
@@ -90,7 +89,7 @@ export const useCreateTrack = () => {
     const tx = {
       module: MODULES.AUDIO,
       command: COMMANDS.CREATE,
-      nonce: BigNumber(data.nonce),
+      nonce: BigInt(data.nonce),
       senderPublicKey: Buffer.from(data.publicKey, 'hex'),
       params: {
         name,

--- a/app/hooks/useCreateEntity/useCreateTrack.ts
+++ b/app/hooks/useCreateEntity/useCreateTrack.ts
@@ -113,6 +113,12 @@ export const useCreateTrack = () => {
       Buffer.from(data.privateKey, 'hex'),
       AUDIO_CREATE_SCHEMA
     );
+    if (!signedTx.id || !Buffer.isBuffer(signedTx.id)) {
+      return {
+        txBytes: '',
+        txId: '',
+      }
+    }
     const txId = signedTx.id.toString('hex');
     const txBytes = transactions.getBytes(signedTx, AUDIO_CREATE_SCHEMA);
     // dry-run transaction to get the errors

--- a/app/hooks/useCreateEntity/useCreateTrack.ts
+++ b/app/hooks/useCreateEntity/useCreateTrack.ts
@@ -113,6 +113,7 @@ export const useCreateTrack = () => {
       Buffer.from(data.privateKey, 'hex'),
       AUDIO_CREATE_SCHEMA
     );
+    const txId = signedTx.id.toString('hex');
     const txBytes = transactions.getBytes(signedTx, AUDIO_CREATE_SCHEMA);
     // dry-run transaction to get the errors
     const dryRunResponse = <DryRunTxResponse> await request(
@@ -120,7 +121,7 @@ export const useCreateTrack = () => {
       { transaction: txBytes.toString('hex') },
     );
     // broadcast transaction
-    const txStatus = getTransactionExecutionStatus(MODULES.SUBSCRIPTION, txId, dryRunResponse.data.events);
+    const txStatus = getTransactionExecutionStatus(MODULES.AUDIO, txId, dryRunResponse);
     if (txStatus === TX_STATUS.SUCCESS) {
       const response = <PostTxResponse> await request(
         Method.txpool_postTransaction,
@@ -157,7 +158,6 @@ export const useCreateTrack = () => {
       }
     } else {
       setFeedback({ message: FEEDBACK_MESSAGES.INVALID_PARAMS, error: true });
-      // Set errors and display to user
     }
   };
 

--- a/app/hooks/useStream/index.ts
+++ b/app/hooks/useStream/index.ts
@@ -10,7 +10,7 @@ import { AUDIO_STREAM_SCHEMA, MODULES, COMMANDS } from '~/constants/blockchain';
 import { CHAIN_ID, TX_STATUS } from '~/constants/app';
 import { ProfileInfoType } from '~/context/profileContext/types';
 import { useWS } from '../useWS/useWS';
-import { getTransactionExecutionStatus } from '~/helpers/helpers';
+import { getTransactionExecutionStatus } from '~/helpers/transaction';
 
 interface CreateTxResponse {
   txBytes: string;

--- a/app/hooks/useStream/index.ts
+++ b/app/hooks/useStream/index.ts
@@ -1,0 +1,91 @@
+import { useState, useEffect } from 'react';
+import { transactions } from '@liskhq/lisk-client';
+
+import {
+  Method,
+  DryRunTxResponse,
+} from '~/context/socketContext/types';
+import { useAccount } from '../useAccount/useAccount';
+import { AUDIO_STREAM_SCHEMA, MODULES, COMMANDS } from '~/constants/blockchain';
+import { CHAIN_ID, TX_STATUS } from '~/constants/app';
+import { ProfileInfoType } from '~/context/profileContext/types';
+import { useWS } from '../useWS/useWS';
+import { getTransactionExecutionStatus } from '~/helpers/helpers';
+
+interface CreateTxResponse {
+  txBytes: string;
+  txId: string;
+}
+
+const createTx = (audioID: string, account: ProfileInfoType): CreateTxResponse => {
+  const tx = {
+    module: MODULES.AUDIO,
+    command: COMMANDS.STREAM,
+    nonce: BigInt(account.nonce),
+    senderPublicKey: Buffer.from(account.publicKey, 'hex'),
+    params: {
+      audioID: Buffer.from(audioID, 'hex'),
+    },
+  };
+  const fee = transactions.computeMinFee(tx, AUDIO_STREAM_SCHEMA);
+  // Sign the transaction
+  const signedTx = transactions.signTransactionWithPrivateKey(
+    { ...tx, fee },
+    Buffer.from(CHAIN_ID, 'hex'),
+    Buffer.from(account.privateKey, 'hex'),
+    AUDIO_STREAM_SCHEMA
+  );
+  const txId = signedTx.id.toString('hex');
+  const txBytes = transactions.getBytes(signedTx, AUDIO_STREAM_SCHEMA);
+  return {
+    txBytes: txBytes.toString('hex'),
+    txId,
+  };
+};
+
+export const useStream = () => {
+  const { updateAccount } = useAccount();
+  const { request } = useWS();
+  const [queue, setQueue] = useState<string[]>([]);
+
+  const registerStream = (audioID: string) => {
+    setQueue((prevQueue) => [...prevQueue, audioID]);
+  };
+
+  const registerOne = async (audioID: string) => {
+    console.log('registerOne', audioID);
+    const account = await updateAccount();
+    console.log('account', account);
+    const { txBytes, txId } = createTx(audioID, account);
+    console.log('CREATE TX', txBytes, txId);
+    const dryRunResponse = <DryRunTxResponse> await request(
+      Method.txpool_dryRunTransaction,
+      { transaction: txBytes },
+    );
+    console.log('dryRunResponse', dryRunResponse);
+    const txStatus = getTransactionExecutionStatus(MODULES.SUBSCRIPTION, txId, dryRunResponse);
+    console.log('txStatus', txStatus);
+
+    if (txStatus === TX_STATUS.SUCCESS) {
+      const response = await request(
+        Method.txpool_postTransaction,
+        { transaction: txBytes },
+      );
+      console.log('response', response);
+
+      if (!response.error) {
+        console.log('Remove from queue');
+        setQueue((prevQueue) => prevQueue.filter(item => item !== audioID));
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (queue.length) {
+      const oldestAudioID = queue[0];
+      registerOne(oldestAudioID);
+    }
+  }, [queue]);
+
+  return { registerStream };
+};

--- a/app/hooks/useStream/index.ts
+++ b/app/hooks/useStream/index.ts
@@ -63,7 +63,7 @@ export const useStream = () => {
       { transaction: txBytes },
     );
     console.log('dryRunResponse', dryRunResponse);
-    const txStatus = getTransactionExecutionStatus(MODULES.SUBSCRIPTION, txId, dryRunResponse);
+    const txStatus = getTransactionExecutionStatus(MODULES.AUDIO, txId, dryRunResponse);
     console.log('txStatus', txStatus);
 
     if (txStatus === TX_STATUS.SUCCESS) {

--- a/app/hooks/useSubscriptions/usePurchaseSubscription.ts
+++ b/app/hooks/useSubscriptions/usePurchaseSubscription.ts
@@ -60,6 +60,12 @@ export const usePurchaseSubscription = () => {
       Buffer.from(info.privateKey, 'hex'),
       SUBSCRIPTION_PURCHASE_SCHEMA
     );
+    if (!signedTx.id || !Buffer.isBuffer(signedTx.id)) {
+      return {
+        txBytes: '',
+        txId: '',
+      }
+    }
     const txId = signedTx.id.toString('hex');
     const txBytes = transactions.getBytes(signedTx, SUBSCRIPTION_PURCHASE_SCHEMA);
     // dry-run transaction to get the errors


### PR DESCRIPTION
### Which issues does this PR address?
Closes #69


### how did you resolve?
- [x] Create `useStream` hook
- [x] Use `useStream` in `useAudio` to submit tx when a new audio is streamed.
- [x] Improve `getTransactionExecutionStatus` to have a consistent return statement.
